### PR TITLE
docs: add file preloading query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 📚 Specification of UniCourse API
 
-Check it out: https://unicourse-tw.github.io/API-Spec/
-
+Check it out: <https://unicourse-tw.github.io/API-Spec/>
 
 ## Development
 
-Using [Swagger Editor](https://editor.swagger.io/) to preview your changes.
+Edit the specification file via [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/UniCourse-TW/API-Spec/main/spec.yaml).
+
+**Please remember to paste back the content after you finish editing.**


### PR DESCRIPTION
Auto load spec file into Swagger Editor via `url` query string.
